### PR TITLE
アクセス時のちらつきをキャッシュにより解消

### DIFF
--- a/frontend/nextjs-project/src/app/login/page.tsx
+++ b/frontend/nextjs-project/src/app/login/page.tsx
@@ -7,22 +7,19 @@ import { useEffect } from "react";
 import OverlayLoader from "@/components/features/loading/OverlayLoader";
 
 export default function LoginPage() {
-  // ログイン済みならマップにリダイレクト
-  const user = useAuthStore((state) => state.user);
-  const initialized = useAuthStore((state) => state.initialized);
+  const status = useAuthStore((state) => state.status);
   const router = useRouter();
+
   useEffect(() => {
-    if (!initialized) {
-      return;
-    }
-    if (user !== null) {
+    // 認証済みになったらトップページへリダイレクト
+    if (status === "authenticated") {
       router.replace("/");
     }
-  }, [user, initialized, router]);
+  }, [status, router]);
 
-  if (!initialized || user !== null) {
+  // 状態が「未認証」で確定するまでは、問答無用ですべてローディング画面
+  if (status !== "unauthenticated") {
     return <OverlayLoader />;
   }
-
   return <LoginView />;
 }


### PR DESCRIPTION
- AUTH_CACHE_KEYを設定し、これが localStorage にあれば認証済みとみなしてあらかじめ認証済みの画面を表示
- 自分のパソコンで動きを確認できなかったので、どなたか確認お願いしたいです